### PR TITLE
CODEOWNERS: gen-cli to Central, gen-web to hAppy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 /.github @JettTech @yegortimoshenko
 /core @yegortimoshenko
-/gen-web @JettTech
+/gen-cli @Holo-Host/central
+/gen-web @Holo-Host/happy


### PR DESCRIPTION
This would make merging changes to `gen-web` a bit easier to do, by allowing anyone from hAppy team to review changes, while making sure that changes to `gen-cli` need to be approved by Central team.