### PR TITLE
.github/settings.yml: allow HoloCentral and hAppy teams to merge PRs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -37,7 +37,9 @@ branches:
       enforce_admins: true
       restrictions:
         users: []
-        teams: []
+        teams:
+        - central
+        - happy
   - name: master
     protection:
       required_pull_request_reviews:
@@ -53,4 +55,6 @@ branches:
       enforce_admins: true
       restrictions:
         users: []
-        teams: []
+        teams:
+        - central
+        - happy


### PR DESCRIPTION
In `.github/settings.yml`, even if someone has push access, they need to be specifically whitelisted to be able to merge PRs to protected branches.