### PR TITLE
Initial implementation of Python 3.7 hpos_config.schema package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ pkg/
 result
 target/
 worker/
+/build/
+/*.egg-info/
+__pycache__/
+/*.eggs/

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { pkgs ? import ./nixpkgs.nix {} }:
 
 with pkgs;
+with python3Packages;
 
 let
   inherit (rust.packages.nightly) rustPlatform;
@@ -69,5 +70,16 @@ in
     buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 
     doCheck = false;
+  };
+
+  hpos-config-py = buildPythonPackage {
+    name = "hpos_config";
+    src = gitignoreSource ./.;
+
+    checkInputs = [ pytest ];
+    checkPhase = ''
+      python3 -m pytest
+    '';
+    meta.platforms = lib.platforms.all;
   };
 }

--- a/hpos_config/__init__.py
+++ b/hpos_config/__init__.py
@@ -1,0 +1,8 @@
+__author__                      = "Perry Kundert"
+__email__                       = "perry.kundert@holo.host"
+__copyright__                   = "Copyright (c) 2020 Holo Limited, Gibralter"
+__license__                     = "Apache License, Version 2.0"
+
+__all__				= [ "schema" ]
+
+from .version import ( __version__, __version_info__ )

--- a/hpos_config/schema.py
+++ b/hpos_config/schema.py
@@ -1,0 +1,77 @@
+__author__                      = "Perry Kundert"
+__email__                       = "perry.kundert@holo.host"
+__copyright__                   = "Copyright (c) 2020 Holo Limited, Gibralter"
+__license__                     = "Apache License, Version 2.0"
+
+import json
+
+CONFIG_FILE = 'hpos-config.json'
+
+def is_email(string):
+    return isinstance(string, str) and '@' in string
+
+CONFIG_SCHEMA = {
+    'v1': {
+        'seed': str,
+        'settings': {
+            'admin': {
+                'email': is_email,
+                'public_key': str
+            }
+        }
+    }
+}
+
+
+def check_schema(schema, data, path=''):
+    """Validate a schema over the supplied data (assumes JSON, if type(str)); dict/list/value validated
+    against dict/list of type, predicate or specific value.
+
+    Raises an Exception on schema failure, with the path indicating where the failure occurred.
+
+    """
+    if isinstance(schema, dict) and isinstance(data, dict):
+        # schema is a dict of types or other dicts
+        for k in schema:
+            subpath = f"{path}.{k}"
+            assert k in data, f"Missing {subpath} with schema {schema[k]!r}"
+            check_schema(schema[k], data[k], path=subpath)
+    elif isinstance(schema, list) and isinstance(data, list):
+        # schema is list in the form [type or dict].  If schema empty, any list will do
+        for i,c in enumerate(data):
+            subpath = f"{path}[{i}]"
+            if len(schema) == 1: # uniform list
+                check_schema(schema[0], c, path=subpath)
+            elif i < len(schema): # list of various types; at least schema length required
+                check_schema(schema[i], c, path=subpath)
+        assert len(schema) <= 1 or len(data) >= len(schema), \
+            f"Missing {path}[{len(data)}:{len(schema)}] with schema {', '.join( f'{s!r}' for s in schema[len(data):len(schema)] )}"
+    elif isinstance(schema, type):
+        # schema is the type of data
+        assert isinstance(data, schema), \
+            f"Expected {path} of type {schema.__name__}"
+    elif hasattr(schema, '__call__'):
+        # schema is the predicate for the data
+        assert schema(data), \
+            f"Expected {path} to satisfy predicate {schema.__name__}"
+    else:
+        # schema is neither a dict, nor list, not type.  Assume its a value.
+        assert schema == data, \
+            f"Expected {path} == {schema!r}"
+
+
+def check_schema_json(schema, data_json, path=''):
+    try:
+        data = json.loads(data_json)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to decode JSON{' for ' if path else ''}{path}: {exc}")
+    check_schema(schema, data, path)
+
+
+def check_config(config):
+    check_schema(CONFIG_SCHEMA, config, path=f"{CONFIG_FILE}: ")
+
+
+def check_config_json(config_json):
+    check_schema_json(CONFIG_SCHEMA, config_json, path=f"{CONFIG_FILE}: ")
+    

--- a/hpos_config/schema_test.py
+++ b/hpos_config/schema_test.py
@@ -1,0 +1,55 @@
+import json
+import pytest
+from hpos_config import schema
+
+config_json = """\
+
+{
+  "v1": {
+    "seed": "YXxZUB9s0eCnJo+lAhlAt2FJKLqT8KP1x2X3qzAZNQs",
+    "settings": {
+      "admin": {
+        "email": "test@example.com",
+        "public_key": "uaUz9m8QNPXNvyuTbdNb3MpQ7iCe6UmWhdQ7ChUlpaQ"
+      },
+      "other": {
+        "ints": [1,2],
+        "stuff": [133]
+      }
+    }
+  }
+}
+"""
+
+def test_config():
+    schema.check_config_json(config_json)
+
+    config = json.loads(config_json)
+    config['v1']['settings']['admin']['email'] = 'boo'
+    with pytest.raises(Exception) as exc:
+        schema.check__config(config)
+
+
+def test_schema_lists():
+    schema.check_schema(
+        {'list': { 'stuff': [int, str, float]}},
+        {'list': { 'stuff': [1, 'a', 1.2, 'something'] }}
+    )
+    with pytest.raises(Exception) as exc:
+        schema.check_schema(
+            {'list': { 'stuff': [int, str, float]}},
+            {'list': { 'stuff': [1, 'a', 'b'] }}
+        )
+    with pytest.raises(Exception) as exc:
+        schema.check_schema(
+            {'list': { 'stuff': [int, str, float]}},
+            {'list': { 'stuff': [1, 'a'] }}
+        )
+    schema.check_schema(
+        {'list': { 'ints': [int]}},
+        {'list': { 'ints': [] }}
+    )
+    schema.check_schema(
+        {'list': { 'ints': [int]}},
+        {'list': { 'ints': [1,1] }}
+    )

--- a/hpos_config/version.py
+++ b/hpos_config/version.py
@@ -1,0 +1,2 @@
+__version_info__		= ( 0, 1, 0 )
+__version__			= '.'.join( map( str, __version_info__ ))

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/fc160c13bd2f88409d09866ea59945b9579dd23a.tar.gz";
-  sha256 = "09wsb9n62rxgr4pqz2z1098xcj8fqwxnq0iv0lhprj15vbkxpgih";
+  url = "https://github.com/Holo-Host/holo-nixpkgs/archive/480519661ca160c8c42df839dbfe6f6324f75bde.tar.gz";
+  sha256 = "092rrbfkzwzksbji6f6rv39xpfkl0zk6zq20iiwc9ssisg5a5rib";
 })

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,52 @@
+__author__                      = "Perry Kundert"
+__email__                       = "perry.kundert@holo.host"
+__copyright__                   = "Copyright (c) 2020 Holo Limited, Gibralter"
+__license__                     = "Apache License, Version 2.0"
+
+from setuptools import setup
+import os
+
+name			= 'hpos-config'
+package			= 'hpos_config'
+
+here			= os.path.abspath( os.path.dirname( __file__ ))
+
+with open( os.path.join( here, package, 'version.py' ), 'r' ) as version:
+    exec( version.read() )
+
+install_requires	= []
+requirements_txt	= os.path.join( here, "requirements.txt" )
+if os.path.exists( requirements_txt ):
+    with open( requirements_txt, 'r' ) as reqirements:
+        install_requires = requirements.readlines()
+
+setup(
+    name		= name,
+    version		= __version__,
+    packages		= [ package ],
+    tests_require	= [ 'pytest' ],
+    install_requires	= install_requires,
+    author		= "Perry Kundert",
+    author_email	= "perry.kundert@holo.host",
+    description		= "Schema validation for HPOS Config",
+    license		= "Apache License, Version 2.0",
+    keywords		= "HPOS config schema validation",
+    url			= "https://github.com/Holo-Host/hpos-config",
+    classifiers		= [
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+    ],
+    long_description		= """\
+The hpos_config Python module provides access to various operations on the
+`hpos-config.json` file to Python 3.7+ programs.
+
+PACKAGES
+
+  .schema  -- validate the data schema on a valid `hpos-config.json` file
+    Only validates the portions required by HPOS, and only at a superficial level; 
+    presence, and basic data type.
+
+"""
+)


### PR DESCRIPTION
This may be used by any Python code that wishes to mutate the hpos-config.json contents, to check that the mutated value contains at least the .v1.settings.seed, and .admin.email and .public_key, with the expected types.

Further schema validations can be easily added (eg. checking for valid base64 or in the future BIP39 seed).

Arbitrary schemas for other data can be defined and validated, and other hpos-config related functionality can be added in additional packages.