### PR TITLE
is-valid: an admin json validation crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpos-config-is-valid"
+version = "0.0.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hpos-config-core 0.0.0",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "http"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
   "gen-cli",
   "gen-web",
   "into-base36-id",
-  "into-keystore"
+  "into-keystore",
+  "is-valid"
 ]

--- a/is-valid/Cargo.toml
+++ b/is-valid/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "hpos-config-is-valid"
+version = "0.0.0"
+authors = [
+  "Sam Rose <sam.rose@holo.host>"
+]
+edition = "2018"
+repository = "https://github.com/Holo-Host/hpos-config"
+
+[dependencies]
+failure = "0.1.5"
+hpos-config-core = { path = "../core" }
+serde_json = "1.0.39"

--- a/is-valid/src/main.rs
+++ b/is-valid/src/main.rs
@@ -1,0 +1,8 @@
+use failure::*;
+use hpos_config_core::*;
+use std::io::stdin;
+
+fn main() -> Fallible<()> {
+    let Config::V1 { .. } = serde_json::from_reader(stdin())?;
+    Ok(())
+}


### PR DESCRIPTION
using hpos-config-core structs for validation

intended way to use this program: hpos-config-is-valid < hpos-config.json

status code 0 on success, status code 1 on failure. on failure, also print error to stderr.