### PR TITLE
replace fallible => anyhow error library in CLI tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,8 +760,8 @@ dependencies = [
 name = "hpos-config-into-base36-id"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ed25519-dalek",
- "failure",
  "hpos-config-core",
  "hpos-config-seed-bundle-explorer",
  "serde_json",
@@ -773,7 +773,7 @@ dependencies = [
 name = "hpos-config-is-valid"
 version = "0.0.1"
 dependencies = [
- "failure",
+ "anyhow",
  "hpos-config-core",
  "serde_json",
 ]
@@ -798,8 +798,8 @@ dependencies = [
 name = "hpos-config-seed-encoder"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ed25519-dalek",
- "failure",
  "hpos-config-core",
  "hpos-config-seed-bundle-explorer",
  "serde_json",

--- a/into-base36-id/Cargo.toml
+++ b/into-base36-id/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Holo-Host/hpos-config"
 
 [dependencies]
 ed25519-dalek = { version = "1.0.0-pre.1" }
-failure = "0.1.5"
+anyhow = "1.0"
 hpos-config-core = { path = "../core" }
 hpos-config-seed-bundle-explorer = { path = "../seed-bundle-explorer" }
 serde_json = "1.0.64"

--- a/into-base36-id/src/main.rs
+++ b/into-base36-id/src/main.rs
@@ -1,12 +1,13 @@
+use anyhow::{Context, Result};
 use ed25519_dalek::*;
-use failure::*;
 use hpos_config_core::*;
 use hpos_config_seed_bundle_explorer::unlock;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use std::fs::File;
 
 #[tokio::main]
-async fn main() -> Fallible<()> {
+async fn main() -> Result<()> {
     #[derive(StructOpt)]
     struct Cli {
         #[structopt(long = "config-path")]
@@ -22,8 +23,9 @@ async fn main() -> Fallible<()> {
         password,
         ..
     } = Cli::from_args();
-    use std::fs::File;
-    let config_file = File::open(config_path).context("failed to open file")?;
+
+    let config_file =
+        File::open(&config_path).context(format!("failed to open file {}", &config_path.to_string_lossy()))?;
     match serde_json::from_reader(config_file)? {
         Config::V1 { seed, .. } => {
             let secret_key = SecretKey::from_bytes(&seed)?;
@@ -32,7 +34,13 @@ async fn main() -> Fallible<()> {
         }
         Config::V2 { device_bundle, .. } => {
             // take in password
-            let Keypair { public, .. } = unlock(&device_bundle, Some(password)).await.unwrap();
+            let Keypair { public, .. } =
+                unlock(&device_bundle, Some(password))
+                    .await
+                    .context(format!(
+                        "unable to unlock the device bundle from {}",
+                        &config_path.to_string_lossy()
+                    ))?;
             println!("{}", public_key::to_base36_id(&public));
         }
     }

--- a/is-valid/Cargo.toml
+++ b/is-valid/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 repository = "https://github.com/Holo-Host/hpos-config"
 
 [dependencies]
-failure = "0.1.5"
+anyhow = "1.0"
 hpos-config-core = { path = "../core" }
 serde_json = "1.0.64"

--- a/is-valid/src/main.rs
+++ b/is-valid/src/main.rs
@@ -1,8 +1,8 @@
-use failure::*;
+use anyhow::Result;
 use hpos_config_core::*;
 use std::io::stdin;
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     match serde_json::from_reader(stdin())? {
         Config::V1 { .. } => Ok(()),
         Config::V2 { .. } => Ok(()),

--- a/seed-encoder/Cargo.toml
+++ b/seed-encoder/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Holo-Host/hpos-config"
 
 [dependencies]
 ed25519-dalek = { version = "1.0.0-pre.1" }
-failure = "0.1.5"
+anyhow = "1.0"
 hpos-config-core = { path = "../core" }
 hpos-config-seed-bundle-explorer = { path = "../seed-bundle-explorer" }
 serde_json = "1.0.64"


### PR DESCRIPTION
This is how I see error handling in CLI tools:
- you have a lib that uses custom errors
- CLI binaries consume those errors
- any user-facing error is created using anyhow lib

Main advantage of this approach are clear and transparent error messages for a CLI user