### PR TITLE
Use separate steps for build and wrangler in github action

### DIFF
--- a/.github/workflows/deploy-to-devnet.yml
+++ b/.github/workflows/deploy-to-devnet.yml
@@ -6,22 +6,24 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Deploy
+    name: Deploy devnet-quickstart
     defaults:
       run:
         working-directory: gen-web
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust 1.59.0
+      - name: Install Rust minimal stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.59.0
           profile: minimal
-          override: true
-      - name: Publish quickstart to devNet
-        uses: cloudflare/wrangler-action@1.3.0
+          toolchain: stable
+      - run: npm ci
+      - name: Build site
+        env:
+          MEMBRANE_PROOF_SERVICE_URL: "https://devnet-membrane-proof-service.holo.host/"
+        run: 'npm run build --if-present'
+      - name: Publish site
+        uses: cloudflare/wrangler-action@1.1.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'gen-web'
-        env:
-          MEMBRANE_PROOF_SERVICE_URL: "https://devnet-membrane-proof-service.holo.host/"

--- a/.github/workflows/deploy-to-mainnet.yml
+++ b/.github/workflows/deploy-to-mainnet.yml
@@ -6,23 +6,25 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Deploy
+    name: Deploy quickstart
     defaults:
       run:
         working-directory: gen-web
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust 1.59.0
+      - name: Install Rust minimal stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.59.0
           profile: minimal
-          override: true
-      - name: Publish quickstart to mainNet
-        uses: cloudflare/wrangler-action@1.3.0
+          toolchain: stable
+      - run: npm ci
+      - name: Build site
+        env:
+          MEMBRANE_PROOF_SERVICE_URL: "https://membrane-proof-service.holo.host/"
+        run: 'npm run build --if-present'
+      - name: Publish site
+        uses: cloudflare/wrangler-action@1.1.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'gen-web'
           environment: mainnet
-        env:
-          MEMBRANE_PROOF_SERVICE_URL: "https://membrane-proof-service.holo.host/"

--- a/gen-web/wrangler.toml
+++ b/gen-web/wrangler.toml
@@ -1,15 +1,14 @@
-name = "devnet-quickstart"
-type = "javascript"
-webpack_config = "webpack.config.js"
 account_id = "18ff2b4e6205b938652998cfca0d8cff"
 zone_id = "35f34e8f9d04ef8c87283ea9fb812989"
+name = "devnet-quickstart"
 route = "devnet-quickstart.holo.host/*"
+type = "javascript"
 
 # [build] section is necessary because of a type = "javascript"
-# Do not change this to type = "webpack" because wrangler is using internally
+# Do not change the type to "webpack" because wrangler is using internally
 # webpack v4 which is incompatible with webpack v^5.59 used in this project
 [build]
-command = "npm ci && npm run build"
+command = "echo 'Deploying build of quickstart from dist directory'"
 
 [build.upload]
 format = "service-worker"
@@ -18,6 +17,6 @@ format = "service-worker"
 bucket = "./dist"
 entry-point = "workers-site"
 
-[env.production]
+[env.mainnet]
 name = "quickstart"
 route = "quickstart.holo.host/*"


### PR DESCRIPTION
This PR is simplifying a build process of quickstart by github action. Instead of using a long chain of sub-processes first static files are built and then deployed in a separate step. 