### PR TITLE
fix: quick-start-status-code

### DIFF
--- a/gen-web/src/index.js
+++ b/gen-web/src/index.js
@@ -529,7 +529,7 @@
         code: registration_code
       })
     })
-    if (response.status === 201) {
+    if (response.status === 201 || response.status === 200) {
       return true
     }
     if (response.status !== 500) {


### PR DESCRIPTION
Allow 200 or 201 status code response from hbs